### PR TITLE
Revert "Bump maven-enforcer-plugin from 3.0.0-M3 to 3.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
-        <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
         <maven-invoker-plugin.version>3.2.2</maven-invoker-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>


### PR DESCRIPTION
This reverts commit 95e6bc53f9db1443177d354eedaacb66816de1c1.

#53 

In cause of bug:
- https://issues.apache.org/jira/browse/MENFORCER-394