### PR TITLE
Revert "Bump maven-dependency-plugin from 3.1.2 to 3.2.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <maven-bundle-plugin.version>5.1.2</maven-bundle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>


### PR DESCRIPTION
This reverts commit 75fac8a16b78ca042eaefc29b1fd354e41e93f2c.

#51 

In cause of bug:
 - https://issues.apache.org/jira/browse/MDEP-753